### PR TITLE
fix: null-check of rootCAParam prior to empty-check

### DIFF
--- a/ankaCloud-server/src/main/java/com/veertu/AnkaCloudClientFactory.java
+++ b/ankaCloud-server/src/main/java/com/veertu/AnkaCloudClientFactory.java
@@ -96,7 +96,7 @@ public class AnkaCloudClientFactory implements CloudClientFactory {
         }
         String rootCA = null;
         String rootCAParam =  cloudClientParameters.getParameter(AnkaConstants.ROOT_CA);
-        if (!rootCAParam.isEmpty()) {
+        if (rootCAParam != null && !rootCAParam.isEmpty()) {
             rootCA = rootCAParam;
         }
 


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
Fixed a NPE by performing a null-check prior to an isEmpty() call.
Problem will exist for any users without an Enterprise or higher license who do not use a SSL certificate with their Anka Controller

## Breaking Change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [X] I have read the **CONTRIBUTING.md** documentation (if available)
- [X] I have branched from the default repo branch (can be master, main, or release/vX.X)
- [X] I have checked that a similar PR does not exist or has been rejected in the past
- [X] PR changes are specific to a feature or bug
- [X] No style/format/cosmetic changes included
- [X] I have used existing style and naming patterns in my changes
- [X] Tests for the changes have been added/updated (if relevant)
- [X] Built/compiled and tested locally
- [X] Docs have been added/updated (if relevant)
- [X] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->
