### PR TITLE
java 11 support

### DIFF
--- a/ankaCloud-server/src/main/java/com/veertu/ankaMgmtSdk/OpenIdConnectAuthenticator.java
+++ b/ankaCloud-server/src/main/java/com/veertu/ankaMgmtSdk/OpenIdConnectAuthenticator.java
@@ -21,7 +21,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.net.ssl.SSLContext;
-import javax.xml.bind.DatatypeConverter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -184,7 +183,7 @@ public class OpenIdConnectAuthenticator {
 
     private NameValuePair makeAuthorization() {
         String authorizationPair = String.format("%s:%s", clientId, clientSecret);
-        String encoded = DatatypeConverter.printBase64Binary(authorizationPair.getBytes());
+        String encoded = java.util.Base64.getEncoder().encodeToString(authorizationPair.getBytes());
         return new BasicNameValuePair("Authorization", String.format("Basic %s", encoded));
     }
 

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -5,11 +5,11 @@
     <display-name>Anka Build Cloud</display-name>
     <version>1.8.0</version>
     <description>Connects TeamCity with Anka Build Cloud</description>
-    <download-url>Plugin download URL</download-url>
+    <download-url>https://veertu.com/downloads/ankabuild-tc-latest</download-url>
     <email>support@veertu.com</email>
-    <vendor>
+    <vendor email="support@veertu.com" url="https://veertu.com">
+      veertu
       <name>Veertu Inc.</name>
-      <url>http://veertu.com</url>
       <logo>https://veertu.com/wp-content/uploads/2020/07/veertu-logo.svg</logo>
     </vendor>
   </info>

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -5,11 +5,11 @@
     <display-name>Anka Build Cloud</display-name>
     <version>1.8.0</version>
     <description>Connects TeamCity with Anka Build Cloud</description>
-    <download-url>https://veertu.com/downloads/ankabuild-tc-latest</download-url>
+    <download-url>Plugin download URL</download-url>
     <email>support@veertu.com</email>
-    <vendor email="support@veertu.com" url="https://veertu.com">
-      veertu
+    <vendor>
       <name>Veertu Inc.</name>
+      <url>http://veertu.com</url>
       <logo>https://veertu.com/wp-content/uploads/2020/07/veertu-logo.svg</logo>
     </vendor>
   </info>


### PR DESCRIPTION
javax.xml.bind package, which includes DatatypeConverter, is not available in Java 11 and later versions. It was deprecated in Java 9, and removed in Java 11.